### PR TITLE
chore: Remove `DeserializeWithEpoch` trait

### DIFF
--- a/libsigner/src/messages.rs
+++ b/libsigner/src/messages.rs
@@ -43,8 +43,8 @@ use clarity::vm::types::QualifiedContractIdentifier;
 use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use stacks_common::codec::{
-    read_next, read_next_at_most, read_next_at_most_with_epoch, read_next_exact, write_next,
-    Error as CodecError, StacksMessageCodec, MAX_MESSAGE_LEN,
+    read_next, read_next_at_most, read_next_exact, write_next, Error as CodecError,
+    StacksMessageCodec, MAX_MESSAGE_LEN,
 };
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::Sha512Trunc256Sum;
@@ -366,7 +366,7 @@ impl StacksMessageCodec for SignerMessage {
                 // I don't think these messages are stored on the blockchain, so `StacksEpochId::latest()` should be fine
                 let transactions: Vec<StacksTransaction> = {
                     let mut bound_read = BoundReader::from_reader(fd, MAX_MESSAGE_LEN as u64);
-                    read_next_at_most_with_epoch(&mut bound_read, u32::MAX, StacksEpochId::latest())
+                    read_next_at_most(&mut bound_read, u32::MAX)
                 }?;
                 SignerMessage::Transactions(transactions)
             }
@@ -1224,7 +1224,7 @@ impl StacksMessageCodec for RejectCode {
                 // I don't think these messages are stored on the blockchain, so `StacksEpochId::latest()` should be fine
                 let transactions: Vec<StacksTransaction> = {
                     let mut bound_read = BoundReader::from_reader(fd, MAX_MESSAGE_LEN as u64);
-                    read_next_at_most_with_epoch(&mut bound_read, u32::MAX, StacksEpochId::latest())
+                    read_next_at_most(&mut bound_read, u32::MAX)
                 }?;
                 RejectCode::MissingTransactions(transactions)
             }

--- a/stacks-common/src/codec/mod.rs
+++ b/stacks-common/src/codec/mod.rs
@@ -87,15 +87,6 @@ pub trait StacksMessageCodec {
     }
 }
 
-pub trait DeserializeWithEpoch {
-    fn consensus_deserialize_with_epoch<R: Read>(
-        fd: &mut R,
-        epoch_id: StacksEpochId,
-    ) -> Result<Self, Error>
-    where
-        Self: Sized;
-}
-
 // impl_byte_array_message_codec!(MARFValue, 40);
 impl_byte_array_message_codec!(SortitionId, 32);
 
@@ -191,66 +182,6 @@ pub fn read_next_exact<R: Read, T: StacksMessageCodec + Sized>(
     num_items: u32,
 ) -> Result<Vec<T>, Error> {
     read_next_vec::<T, R>(fd, num_items, 0)
-}
-
-pub fn read_next_with_epoch<T: DeserializeWithEpoch, R: Read>(
-    fd: &mut R,
-    epoch_id: StacksEpochId,
-) -> Result<T, Error> {
-    let item: T = T::consensus_deserialize_with_epoch(fd, epoch_id)?;
-    Ok(item)
-}
-
-fn read_next_vec_with_epoch<T: DeserializeWithEpoch + Sized, R: Read>(
-    fd: &mut R,
-    num_items: u32,
-    max_items: u32,
-    epoch_id: StacksEpochId,
-) -> Result<Vec<T>, Error> {
-    let len = u32::consensus_deserialize(fd)?;
-
-    if max_items > 0 {
-        if len > max_items {
-            // too many items
-            return Err(Error::DeserializeError(format!(
-                "Array has too many items ({} > {}",
-                len, max_items
-            )));
-        }
-    } else {
-        if len != num_items {
-            // inexact item count
-            return Err(Error::DeserializeError(format!(
-                "Array has incorrect number of items ({} != {})",
-                len, num_items
-            )));
-        }
-    }
-
-    if (mem::size_of::<T>() as u128) * (len as u128) > MAX_MESSAGE_LEN as u128 {
-        return Err(Error::DeserializeError(format!(
-            "Message occupies too many bytes (tried to allocate {}*{}={})",
-            mem::size_of::<T>() as u128,
-            len,
-            (mem::size_of::<T>() as u128) * (len as u128)
-        )));
-    }
-
-    let mut ret = Vec::with_capacity(len as usize);
-    for _i in 0..len {
-        let next_item = T::consensus_deserialize_with_epoch(fd, epoch_id)?;
-        ret.push(next_item);
-    }
-
-    Ok(ret)
-}
-
-pub fn read_next_at_most_with_epoch<R: Read, T: DeserializeWithEpoch + Sized>(
-    fd: &mut R,
-    max_items: u32,
-    epoch_id: StacksEpochId,
-) -> Result<Vec<T>, Error> {
-    read_next_vec_with_epoch::<T, R>(fd, 0, max_items, epoch_id)
 }
 
 impl<T> StacksMessageCodec for Vec<T>

--- a/stackslib/src/blockstack_cli.rs
+++ b/stackslib/src/blockstack_cli.rs
@@ -46,7 +46,7 @@ use clarity::vm::errors::{Error as ClarityError, RuntimeErrorType};
 use clarity::vm::types::PrincipalData;
 use clarity::vm::{ClarityName, ClarityVersion, ContractName, Value};
 use stacks_common::address::{b58, AddressHashMode};
-use stacks_common::codec::{DeserializeWithEpoch, Error as CodecError, StacksMessageCodec};
+use stacks_common::codec::{Error as CodecError, StacksMessageCodec};
 use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::types::StacksEpochId;
 use stacks_common::util::hash::{hex_bytes, to_hex};
@@ -315,10 +315,8 @@ fn sign_transaction_single_sig_standard(
     transaction: &str,
     secret_key: &StacksPrivateKey,
 ) -> Result<StacksTransaction, CliError> {
-    let transaction = StacksTransaction::consensus_deserialize_with_epoch(
-        &mut io::Cursor::new(&hex_bytes(transaction)?),
-        StacksEpochId::latest(),
-    )?;
+    let transaction =
+        StacksTransaction::consensus_deserialize(&mut io::Cursor::new(&hex_bytes(transaction)?))?;
 
     let mut tx_signer = StacksTransactionSigner::new(&transaction);
     tx_signer.sign_origin(secret_key)?;
@@ -665,10 +663,7 @@ fn decode_transaction(args: &[String], _version: TransactionVersion) -> Result<S
     let mut cursor = io::Cursor::new(&tx_str);
     let mut debug_cursor = LogReader::from_reader(&mut cursor);
 
-    match StacksTransaction::consensus_deserialize_with_epoch(
-        &mut debug_cursor,
-        StacksEpochId::latest(),
-    ) {
+    match StacksTransaction::consensus_deserialize(&mut debug_cursor) {
         Ok(tx) => Ok(serde_json::to_string(&tx).expect("Failed to serialize transaction to JSON")),
         Err(e) => {
             let mut ret = String::new();
@@ -744,8 +739,7 @@ fn decode_block(args: &[String], _version: TransactionVersion) -> Result<String,
     let mut cursor = io::Cursor::new(&block_data);
     let mut debug_cursor = LogReader::from_reader(&mut cursor);
 
-    match StacksBlock::consensus_deserialize_with_epoch(&mut debug_cursor, StacksEpochId::latest())
-    {
+    match StacksBlock::consensus_deserialize(&mut debug_cursor) {
         Ok(block) => Ok(serde_json::to_string(&block).expect("Failed to serialize block to JSON")),
         Err(e) => {
             let mut ret = String::new();

--- a/stackslib/src/chainstate/nakamoto/tests/mod.rs
+++ b/stackslib/src/chainstate/nakamoto/tests/mod.rs
@@ -27,7 +27,7 @@ use rand::{thread_rng, RngCore};
 use rusqlite::{Connection, ToSql};
 use stacks_common::address::AddressHashMode;
 use stacks_common::bitvec::BitVec;
-use stacks_common::codec::{DeserializeWithEpoch, StacksMessageCodec};
+use stacks_common::codec::StacksMessageCodec;
 use stacks_common::consts::{
     CHAIN_ID_MAINNET, CHAIN_ID_TESTNET, FIRST_BURNCHAIN_CONSENSUS_HASH, FIRST_STACKS_BLOCK_HASH,
 };
@@ -101,10 +101,7 @@ impl<'a> NakamotoStagingBlocksConnRef<'a> {
         let block_data: Vec<Vec<u8>> = query_rows(self, qry, args)?;
         let mut blocks = Vec::with_capacity(block_data.len());
         for data in block_data.into_iter() {
-            let block = NakamotoBlock::consensus_deserialize_with_epoch(
-                &mut data.as_slice(),
-                StacksEpochId::latest(),
-            )?;
+            let block = NakamotoBlock::consensus_deserialize(&mut data.as_slice())?;
             blocks.push(block);
         }
         Ok(blocks)

--- a/stackslib/src/net/api/getblock.rs
+++ b/stackslib/src/net/api/getblock.rs
@@ -20,7 +20,7 @@ use std::{fs, io};
 
 use regex::{Captures, Regex};
 use serde::de::Error as de_Error;
-use stacks_common::codec::{DeserializeWithEpoch, StacksMessageCodec, MAX_MESSAGE_LEN};
+use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::types::net::PeerHost;
 use stacks_common::types::StacksEpochId;
@@ -303,10 +303,7 @@ impl StacksHttpResponse {
 
         // contents will be raw bytes
         let block_bytes: Vec<u8> = contents.try_into()?;
-        let block = StacksBlock::consensus_deserialize_with_epoch(
-            &mut &block_bytes[..],
-            StacksEpochId::Epoch25,
-        )?;
+        let block = StacksBlock::consensus_deserialize(&mut &block_bytes[..])?;
 
         Ok(block)
     }
@@ -318,7 +315,7 @@ impl StacksHttpResponse {
 
         // contents will be raw bytes
         let block_bytes: Vec<u8> = contents.try_into()?;
-        let block = StacksBlock::consensus_deserialize_with_epoch(&mut &block_bytes[..], epoch_id)?;
+        let block = StacksBlock::consensus_deserialize(&mut &block_bytes[..])?;
 
         Ok(block)
     }

--- a/stackslib/src/net/api/getblock_v3.rs
+++ b/stackslib/src/net/api/getblock_v3.rs
@@ -20,7 +20,7 @@ use std::{fs, io};
 use regex::{Captures, Regex};
 use rusqlite::Connection;
 use serde::de::Error as de_Error;
-use stacks_common::codec::{DeserializeWithEpoch, StacksMessageCodec, MAX_MESSAGE_LEN};
+use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
 use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
 use stacks_common::types::net::PeerHost;
 use stacks_common::types::StacksEpochId;
@@ -318,10 +318,7 @@ impl StacksHttpResponse {
 
         // contents will be raw bytes
         let block_bytes: Vec<u8> = contents.try_into()?;
-        let block = NakamotoBlock::consensus_deserialize_with_epoch(
-            &mut &block_bytes[..],
-            StacksEpochId::latest(),
-        )?;
+        let block = NakamotoBlock::consensus_deserialize(&mut &block_bytes[..])?;
 
         Ok(block)
     }

--- a/stackslib/src/net/api/gettenure.rs
+++ b/stackslib/src/net/api/gettenure.rs
@@ -19,7 +19,7 @@ use std::{fs, io};
 
 use regex::{Captures, Regex};
 use serde::de::Error as de_Error;
-use stacks_common::codec::{DeserializeWithEpoch, StacksMessageCodec, MAX_MESSAGE_LEN};
+use stacks_common::codec::{StacksMessageCodec, MAX_MESSAGE_LEN};
 use stacks_common::types::chainstate::{ConsensusHash, StacksBlockId};
 use stacks_common::types::net::PeerHost;
 use stacks_common::types::StacksEpochId;
@@ -356,8 +356,7 @@ impl StacksHttpResponse {
 
         let mut blocks = vec![];
         while ptr.len() > 0 {
-            let block =
-                NakamotoBlock::consensus_deserialize_with_epoch(ptr, StacksEpochId::latest())?;
+            let block = NakamotoBlock::consensus_deserialize(ptr)?;
             blocks.push(block);
         }
 

--- a/stackslib/src/net/api/postblock.rs
+++ b/stackslib/src/net/api/postblock.rs
@@ -18,7 +18,7 @@ use std::io::{Read, Write};
 
 use clarity::vm::costs::ExecutionCost;
 use regex::{Captures, Regex};
-use stacks_common::codec::{DeserializeWithEpoch, Error as CodecError, MAX_PAYLOAD_LEN};
+use stacks_common::codec::{Error as CodecError, StacksMessageCodec, MAX_PAYLOAD_LEN};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, ConsensusHash, StacksBlockId, StacksPublicKey,
 };
@@ -74,18 +74,13 @@ impl RPCPostBlockRequestHandler {
 
     /// Decode a bare block from the body
     fn parse_postblock_octets(mut body: &[u8]) -> Result<StacksBlock, Error> {
-        let block =
-            StacksBlock::consensus_deserialize_with_epoch(&mut body, StacksEpochId::Epoch25)
-                .map_err(|e| {
-                    if let CodecError::DeserializeError(msg) = e {
-                        Error::DecodeError(format!(
-                            "Failed to deserialize posted transaction: {}",
-                            msg
-                        ))
-                    } else {
-                        e.into()
-                    }
-                })?;
+        let block = StacksBlock::consensus_deserialize(&mut body).map_err(|e| {
+            if let CodecError::DeserializeError(msg) = e {
+                Error::DecodeError(format!("Failed to deserialize posted transaction: {}", msg))
+            } else {
+                e.into()
+            }
+        })?;
         Ok(block)
     }
 }

--- a/stackslib/src/net/api/posttransaction.rs
+++ b/stackslib/src/net/api/posttransaction.rs
@@ -18,9 +18,7 @@ use std::io::{Read, Write};
 
 use clarity::vm::costs::ExecutionCost;
 use regex::{Captures, Regex};
-use stacks_common::codec::{
-    DeserializeWithEpoch, Error as CodecError, StacksMessageCodec, MAX_PAYLOAD_LEN,
-};
+use stacks_common::codec::{Error as CodecError, StacksMessageCodec, MAX_PAYLOAD_LEN};
 use stacks_common::types::chainstate::{
     BlockHeaderHash, ConsensusHash, StacksBlockId, StacksPublicKey,
 };
@@ -70,18 +68,13 @@ impl RPCPostTransactionRequestHandler {
 
     /// Decode a bare transaction from the body
     fn parse_posttransaction_octets(mut body: &[u8]) -> Result<StacksTransaction, Error> {
-        let tx =
-            StacksTransaction::consensus_deserialize_with_epoch(&mut body, StacksEpochId::latest())
-                .map_err(|e| {
-                    if let CodecError::DeserializeError(msg) = e {
-                        Error::DecodeError(format!(
-                            "Failed to deserialize posted transaction: {}",
-                            msg
-                        ))
-                    } else {
-                        e.into()
-                    }
-                })?;
+        let tx = StacksTransaction::consensus_deserialize(&mut body).map_err(|e| {
+            if let CodecError::DeserializeError(msg) = e {
+                Error::DecodeError(format!("Failed to deserialize posted transaction: {}", msg))
+            } else {
+                e.into()
+            }
+        })?;
         Ok(tx)
     }
 
@@ -95,11 +88,7 @@ impl RPCPostTransactionRequestHandler {
         let tx = {
             let tx_bytes = hex_bytes(&body.tx)
                 .map_err(|_e| Error::DecodeError("Failed to parse tx".into()))?;
-            StacksTransaction::consensus_deserialize_with_epoch(
-                &mut &tx_bytes[..],
-                StacksEpochId::latest(),
-            )
-            .map_err(|e| {
+            StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).map_err(|e| {
                 if let CodecError::DeserializeError(msg) = e {
                     Error::DecodeError(format!("Failed to deserialize posted transaction: {}", msg))
                 } else {

--- a/stackslib/src/net/api/tests/getblock.rs
+++ b/stackslib/src/net/api/tests/getblock.rs
@@ -18,7 +18,6 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use clarity::vm::types::{QualifiedContractIdentifier, StacksAddressExtensions};
 use clarity::vm::{ClarityName, ContractName};
-use stacks_common::codec::DeserializeWithEpoch;
 use stacks_common::types::chainstate::{
     ConsensusHash, StacksAddress, StacksBlockId, StacksPrivateKey,
 };
@@ -161,11 +160,7 @@ fn test_stream_blocks() {
     }
 
     // should decode back into the block
-    let staging_block = StacksBlock::consensus_deserialize_with_epoch(
-        &mut &all_block_bytes[..],
-        StacksEpochId::Epoch25,
-    )
-    .unwrap();
+    let staging_block = StacksBlock::consensus_deserialize(&mut &all_block_bytes[..]).unwrap();
     assert_eq!(staging_block, block);
 
     // accept it
@@ -190,10 +185,6 @@ fn test_stream_blocks() {
     }
 
     // should decode back into the block
-    let staging_block = StacksBlock::consensus_deserialize_with_epoch(
-        &mut &all_block_bytes[..],
-        StacksEpochId::Epoch25,
-    )
-    .unwrap();
+    let staging_block = StacksBlock::consensus_deserialize(&mut &all_block_bytes[..]).unwrap();
     assert_eq!(staging_block, block);
 }

--- a/stackslib/src/net/api/tests/getblock_v3.rs
+++ b/stackslib/src/net/api/tests/getblock_v3.rs
@@ -18,7 +18,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use clarity::vm::types::{QualifiedContractIdentifier, StacksAddressExtensions};
 use clarity::vm::{ClarityName, ContractName};
-use stacks_common::codec::{DeserializeWithEpoch, StacksMessageCodec};
+use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{
     ConsensusHash, StacksAddress, StacksBlockId, StacksPrivateKey,
 };
@@ -183,10 +183,6 @@ fn test_stream_nakamoto_blocks() {
         all_block_bytes.append(&mut next_bytes);
     }
 
-    let staging_block = NakamotoBlock::consensus_deserialize_with_epoch(
-        &mut &all_block_bytes[..],
-        StacksEpochId::latest(),
-    )
-    .unwrap();
+    let staging_block = NakamotoBlock::consensus_deserialize(&mut &all_block_bytes[..]).unwrap();
     assert_eq!(staging_block.header.block_id(), nakamoto_tip_block_id);
 }

--- a/stackslib/src/net/api/tests/gettenure.rs
+++ b/stackslib/src/net/api/tests/gettenure.rs
@@ -18,7 +18,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use clarity::vm::types::{QualifiedContractIdentifier, StacksAddressExtensions};
 use clarity::vm::{ClarityName, ContractName};
-use stacks_common::codec::{DeserializeWithEpoch, StacksMessageCodec};
+use stacks_common::codec::StacksMessageCodec;
 use stacks_common::types::chainstate::{
     ConsensusHash, StacksAddress, StacksBlockId, StacksPrivateKey,
 };
@@ -192,8 +192,7 @@ fn test_stream_nakamoto_tenure() {
     let ptr = &mut all_block_bytes.as_slice();
     let mut blocks = vec![];
     while ptr.len() > 0 {
-        let block =
-            NakamotoBlock::consensus_deserialize_with_epoch(ptr, StacksEpochId::latest()).unwrap();
+        let block = NakamotoBlock::consensus_deserialize(ptr).unwrap();
         blocks.push(block);
     }
 

--- a/stackslib/src/net/codec.rs
+++ b/stackslib/src/net/codec.rs
@@ -1554,7 +1554,7 @@ impl ProtocolFamily for StacksP2P {
 #[cfg(test)]
 pub mod test {
     use stacks_common::bitvec::BitVec;
-    use stacks_common::codec::{DeserializeWithEpoch, NEIGHBOR_ADDRESS_ENCODED_SIZE};
+    use stacks_common::codec::NEIGHBOR_ADDRESS_ENCODED_SIZE;
     use stacks_common::types::StacksEpochId;
     use stacks_common::util::hash::hex_bytes;
     use stacks_common::util::secp256k1::*;
@@ -1645,62 +1645,6 @@ pub mod test {
             short_buf.truncate(short_len);
 
             let underflow_res = T::consensus_deserialize(&mut &short_buf[..]);
-            match underflow_res {
-                Ok(oops) => {
-                    test_debug!(
-                        "\nMissing Underflow: Parsed {:?}\nFrom {:?}\n",
-                        &oops,
-                        &write_buf[0..short_len].to_vec()
-                    );
-                }
-                Err(codec_error::ReadError(io_error)) => match io_error.kind() {
-                    io::ErrorKind::UnexpectedEof => {}
-                    _ => {
-                        test_debug!("Got unexpected I/O error: {:?}", &io_error);
-                        assert!(false);
-                    }
-                },
-                Err(e) => {
-                    test_debug!("Got unexpected Net error: {:?}", &e);
-                    assert!(false);
-                }
-            };
-        }
-    }
-
-    pub fn check_codec_and_corruption_with_epoch<
-        T: StacksMessageCodec + fmt::Debug + Clone + PartialEq + DeserializeWithEpoch,
-    >(
-        obj: &T,
-        bytes: &Vec<u8>,
-        epoch_id: StacksEpochId,
-    ) -> () {
-        // obj should serialize to bytes
-        let mut write_buf: Vec<u8> = Vec::with_capacity(bytes.len());
-        obj.consensus_serialize(&mut write_buf).unwrap();
-        assert_eq!(write_buf, *bytes);
-
-        // bytes should deserialize to obj
-        let read_buf: Vec<u8> = write_buf.clone();
-        let res = T::consensus_deserialize_with_epoch(&mut &read_buf[..], epoch_id);
-        match res {
-            Ok(out) => {
-                assert_eq!(out, *obj);
-            }
-            Err(e) => {
-                test_debug!("\nFailed to parse to {:?}: {:?}", obj, bytes);
-                test_debug!("error: {:?}", &e);
-                assert!(false);
-            }
-        }
-
-        // short message shouldn't parse, but should EOF
-        if write_buf.len() > 0 {
-            let mut short_buf = write_buf.clone();
-            let short_len = short_buf.len() - 1;
-            short_buf.truncate(short_len);
-
-            let underflow_res = T::consensus_deserialize_with_epoch(&mut &short_buf[..], epoch_id);
             match underflow_res {
                 Ok(oops) => {
                     test_debug!(

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -921,7 +921,7 @@ impl Node {
                 &metadata.anchored_header.block_hash(),
             )
             .unwrap();
-            StacksChainState::consensus_load_with_epoch(&block_path, stacks_epoch.epoch_id).unwrap()
+            StacksChainState::consensus_load(&block_path).unwrap()
         };
 
         let chain_tip = ChainTip {

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -18,7 +18,6 @@ use stacks::core::{
     StacksEpoch, StacksEpochId, PEER_VERSION_EPOCH_1_0, PEER_VERSION_EPOCH_2_0,
     PEER_VERSION_EPOCH_2_05, PEER_VERSION_EPOCH_2_1,
 };
-use stacks_common::codec::DeserializeWithEpoch;
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, StacksAddress, VRFSeed,
 };
@@ -231,11 +230,7 @@ fn test_exact_block_costs() {
             .filter_map(|tx| {
                 let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
                 let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-                let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut &tx_bytes[..],
-                    StacksEpochId::Epoch2_05,
-                )
-                .unwrap();
+                let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
                 if let TransactionPayload::ContractCall(ref cc) = &parsed.payload {
                     if cc.function_name.as_str() == "db-get2" {
                         Some(parsed)
@@ -425,11 +420,7 @@ fn test_dynamic_db_method_costs() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut &tx_bytes[..],
-                StacksEpochId::Epoch2_05,
-            )
-            .unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
 
             if let TransactionPayload::ContractCall(ref cc) = parsed.payload {
                 assert_eq!(
@@ -1172,11 +1163,7 @@ fn bigger_microblock_streams_in_2_05() {
                     continue;
                 }
                 let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-                let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut &tx_bytes[..],
-                    StacksEpochId::Epoch2_05,
-                )
-                .unwrap();
+                let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
                 if let TransactionPayload::SmartContract(tsc, ..) = parsed.payload {
                     if tsc.name.to_string().find("costs-2").is_some() {
                         in_205 = true;

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -26,7 +26,6 @@ use stacks::clarity_cli::vm_execute as execute;
 use stacks::core;
 use stacks::core::BURNCHAIN_TX_SEARCH_WINDOW;
 use stacks::util_lib::boot::boot_code_id;
-use stacks_common::codec::DeserializeWithEpoch;
 use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, StacksAddress, StacksBlockId, VRFSeed,
 };
@@ -385,10 +384,9 @@ fn transition_adds_burn_block_height() {
     );
     submit_tx(&http_origin, &tx);
 
-    let cc_txid =
-        StacksTransaction::consensus_deserialize_with_epoch(&mut &tx[..], StacksEpochId::Epoch21)
-            .unwrap()
-            .txid();
+    let cc_txid = StacksTransaction::consensus_deserialize(&mut &tx[..])
+        .unwrap()
+        .txid();
 
     // mine it
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
@@ -407,11 +405,7 @@ fn transition_adds_burn_block_height() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut &tx_bytes[..],
-                StacksEpochId::Epoch21,
-            )
-            .unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
             if parsed.txid() == cc_txid {
                 // check events for this block
                 for event in events.iter() {
@@ -1227,12 +1221,9 @@ fn transition_adds_get_pox_addr_recipients() {
         "test-get-pox-addrs",
         &[Value::UInt((stack_sort_height).into())],
     );
-    let cc_txid = StacksTransaction::consensus_deserialize_with_epoch(
-        &mut &cc_tx[..],
-        StacksEpochId::Epoch21,
-    )
-    .unwrap()
-    .txid();
+    let cc_txid = StacksTransaction::consensus_deserialize(&mut &cc_tx[..])
+        .unwrap()
+        .txid();
 
     submit_tx(&http_origin, &cc_tx);
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
@@ -1251,11 +1242,7 @@ fn transition_adds_get_pox_addr_recipients() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut &tx_bytes[..],
-                StacksEpochId::Epoch21,
-            )
-            .unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
             if parsed.txid() == cc_txid {
                 // check events for this block
                 for (_i, event) in events.iter().enumerate() {
@@ -1985,11 +1972,7 @@ fn transition_empty_blocks() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut &tx_bytes[..],
-                StacksEpochId::Epoch21,
-            )
-            .unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
             if let TransactionPayload::SmartContract(tsc, ..) = parsed.payload {
                 if tsc.name == "pox-2".into() {
                     have_pox2 = true;
@@ -4910,11 +4893,7 @@ fn trait_invocation_cross_epoch() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut &tx_bytes[..],
-                StacksEpochId::Epoch21,
-            )
-            .unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
             if interesting_txids.contains(&parsed.txid().to_string()) {
                 eprintln!(
                     "{} => {}",

--- a/testnet/stacks-node/src/tests/epoch_22.rs
+++ b/testnet/stacks-node/src/tests/epoch_22.rs
@@ -11,7 +11,6 @@ use stacks::clarity_cli::vm_execute as execute;
 use stacks::core;
 use stacks::core::STACKS_EPOCH_MAX;
 use stacks::util_lib::boot::boot_code_id;
-use stacks_common::codec::DeserializeWithEpoch;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
 use stacks_common::types::PrivateKey;
 use stacks_common::util::hash::Hash160;
@@ -541,11 +540,8 @@ fn disable_pox() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut tx_bytes.as_slice(),
-                StacksEpochId::Epoch22,
-            )
-            .unwrap();
+            let parsed =
+                StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
             let tx_sender = PrincipalData::from(parsed.auth.origin().address_testnet());
             if &tx_sender == &spender_addr
                 && parsed.auth.get_origin_nonce() == aborted_increase_nonce
@@ -1201,11 +1197,8 @@ fn pox_2_unlock_all() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut tx_bytes.as_slice(),
-                StacksEpochId::Epoch22,
-            )
-            .unwrap();
+            let parsed =
+                StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
             let tx_sender = PrincipalData::from(parsed.auth.origin().address_testnet());
             if &tx_sender == &spender_addr
                 && parsed.auth.get_origin_nonce() == nonce_of_2_2_unlock_ht_call

--- a/testnet/stacks-node/src/tests/epoch_23.rs
+++ b/testnet/stacks-node/src/tests/epoch_23.rs
@@ -20,7 +20,6 @@ use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use stacks::burnchains::{Burnchain, PoxConstants};
 use stacks::core;
 use stacks::core::STACKS_EPOCH_MAX;
-use stacks_common::codec::DeserializeWithEpoch;
 use stacks_common::util::sleep_ms;
 
 use crate::config::{EventKeyType, EventObserverConfig, InitialBalance};
@@ -509,11 +508,8 @@ fn trait_invocation_behavior() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut tx_bytes.as_slice(),
-                StacksEpochId::Epoch23,
-            )
-            .unwrap();
+            let parsed =
+                StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
             let tx_sender = PrincipalData::from(parsed.auth.origin().address_testnet());
             if &tx_sender == &spender_addr {
                 let contract_call = match &parsed.payload {

--- a/testnet/stacks-node/src/tests/epoch_24.rs
+++ b/testnet/stacks-node/src/tests/epoch_24.rs
@@ -28,7 +28,6 @@ use stacks::chainstate::stacks::{Error, StacksTransaction, TransactionPayload};
 use stacks::clarity_cli::vm_execute as execute;
 use stacks::core;
 use stacks_common::address::{AddressHashMode, C32_ADDRESS_VERSION_TESTNET_SINGLESIG};
-use stacks_common::codec::DeserializeWithEpoch;
 use stacks_common::consts::STACKS_EPOCH_MAX;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId, StacksPrivateKey};
 use stacks_common::types::{Address, StacksEpochId};
@@ -645,11 +644,8 @@ fn fix_to_pox_contract() {
                 continue;
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed = StacksTransaction::consensus_deserialize_with_epoch(
-                &mut tx_bytes.as_slice(),
-                StacksEpochId::Epoch24,
-            )
-            .unwrap();
+            let parsed =
+                StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
             let tx_sender = PrincipalData::from(parsed.auth.origin().address_testnet());
             if &tx_sender == &spender_addr
                 && (parsed.auth.get_origin_nonce() == aborted_increase_nonce_2_2

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -22,7 +22,7 @@ use stacks::chainstate::stacks::{
     TransactionContractCall, TransactionPayload,
 };
 use stacks::clarity_vm::clarity::ClarityConnection;
-use stacks::codec::{DeserializeWithEpoch, StacksMessageCodec};
+use stacks::codec::StacksMessageCodec;
 use stacks::core::mempool::MAXIMUM_MEMPOOL_TX_CHAINING;
 use stacks::core::{
     StacksEpoch, StacksEpochId, PEER_VERSION_EPOCH_2_0, PEER_VERSION_EPOCH_2_05,
@@ -832,7 +832,7 @@ fn integration_test_get_info() {
                 let tx_xfer_invalid = make_stacks_transfer(&spender_sk, (round + 30).into(), 200,     // bad nonce
                                                            &StacksAddress::from_string(ADDR_4).unwrap().into(), 456);
 
-                let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize_with_epoch(&mut &tx_xfer_invalid[..], StacksEpochId::latest()).unwrap();
+                let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
 
                 let res = client.post(&path)
                     .header("Content-Type", "application/octet-stream")
@@ -1197,11 +1197,9 @@ fn contract_stx_transfer() {
                         &contract_identifier.clone().into(),
                         1000,
                     );
-                    let xfer_to_contract = StacksTransaction::consensus_deserialize_with_epoch(
-                        &mut &xfer_to_contract[..],
-                        StacksEpochId::latest(),
-                    )
-                    .unwrap();
+                    let xfer_to_contract =
+                        StacksTransaction::consensus_deserialize(&mut &xfer_to_contract[..])
+                            .unwrap();
                     tenure
                         .mem_pool
                         .submit(
@@ -1219,11 +1217,8 @@ fn contract_stx_transfer() {
                 // this one should fail because the nonce is already in the mempool
                 let xfer_to_contract =
                     make_stacks_transfer(&sk_3, 3, 190, &contract_identifier.clone().into(), 1000);
-                let xfer_to_contract = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut &xfer_to_contract[..],
-                    StacksEpochId::latest(),
-                )
-                .unwrap();
+                let xfer_to_contract =
+                    StacksTransaction::consensus_deserialize(&mut &xfer_to_contract[..]).unwrap();
                 match tenure
                     .mem_pool
                     .submit(
@@ -2184,11 +2179,8 @@ fn mempool_errors() {
                     &send_to,
                     456,
                 );
-                let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut &tx_xfer_invalid[..],
-                    StacksEpochId::latest(),
-                )
-                .unwrap();
+                let tx_xfer_invalid_tx =
+                    StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
 
                 let res = client
                     .post(&path)
@@ -2228,11 +2220,8 @@ fn mempool_errors() {
                     &send_to,
                     456,
                 );
-                let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut &tx_xfer_invalid[..],
-                    StacksEpochId::latest(),
-                )
-                .unwrap();
+                let tx_xfer_invalid_tx =
+                    StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
 
                 let res = client
                     .post(&path)
@@ -2264,11 +2253,8 @@ fn mempool_errors() {
                     &send_to,
                     456,
                 );
-                let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut &tx_xfer_invalid[..],
-                    StacksEpochId::latest(),
-                )
-                .unwrap();
+                let tx_xfer_invalid_tx =
+                    StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
 
                 let res = client
                     .post(&path)
@@ -2311,11 +2297,8 @@ fn mempool_errors() {
                     &send_to,
                     1000,
                 );
-                let tx_xfer_invalid_tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut &tx_xfer_invalid[..],
-                    StacksEpochId::latest(),
-                )
-                .unwrap();
+                let tx_xfer_invalid_tx =
+                    StacksTransaction::consensus_deserialize(&mut &tx_xfer_invalid[..]).unwrap();
 
                 let res = client
                     .post(&path)

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -13,7 +13,7 @@ use stacks::chainstate::stacks::{
     TransactionAnchorMode, TransactionAuth, TransactionPayload, TransactionSpendingCondition,
     TransactionVersion, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
 };
-use stacks::codec::{DeserializeWithEpoch, StacksMessageCodec};
+use stacks::codec::StacksMessageCodec;
 use stacks::core::mempool::MemPoolDB;
 use stacks::core::{StacksEpochId, CHAIN_ID_TESTNET};
 use stacks::cost_estimates::metrics::UnitMetric;
@@ -236,11 +236,8 @@ fn mempool_setup_chainstate() {
                 // first a couple valid ones:
                 let tx_bytes =
                     make_contract_publish(&contract_sk, 5, 1000, "bar_contract", FOO_CONTRACT);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -260,11 +257,8 @@ fn mempool_setup_chainstate() {
                     "bar",
                     &[Value::UInt(1)],
                 );
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -276,11 +270,8 @@ fn mempool_setup_chainstate() {
                     .unwrap();
 
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 200, &other_addr, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -293,11 +284,8 @@ fn mempool_setup_chainstate() {
 
                 // bad signature
                 let tx_bytes = make_bad_stacks_transfer(&contract_sk, 5, 200, &other_addr, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -338,11 +326,8 @@ fn mempool_setup_chainstate() {
                     "bar",
                     &[Value::UInt(1), Value::Int(2)],
                 );
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -370,11 +355,8 @@ fn mempool_setup_chainstate() {
                 .into();
 
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 200, &bad_addr, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -392,11 +374,8 @@ fn mempool_setup_chainstate() {
 
                 // bad fees
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 0, &other_addr, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -415,11 +394,8 @@ fn mempool_setup_chainstate() {
 
                 // bad nonce
                 let tx_bytes = make_stacks_transfer(&contract_sk, 0, 200, &other_addr, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -438,11 +414,8 @@ fn mempool_setup_chainstate() {
 
                 // not enough funds
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 110000, &other_addr, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -462,11 +435,8 @@ fn mempool_setup_chainstate() {
                 // sender == recipient
                 let contract_princ = PrincipalData::from(contract_addr.clone());
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 300, &contract_princ, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -488,11 +458,8 @@ fn mempool_setup_chainstate() {
                 mainnet_recipient.version = C32_ADDRESS_VERSION_MAINNET_SINGLESIG;
                 let mainnet_princ = mainnet_recipient.into();
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 300, &mainnet_princ, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -524,11 +491,8 @@ fn mempool_setup_chainstate() {
                     TransactionAnchorMode::OnChainOnly,
                     TransactionVersion::Mainnet,
                 );
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -547,11 +511,8 @@ fn mempool_setup_chainstate() {
 
                 // send amount must be positive
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 300, &other_addr, 0);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -570,11 +531,8 @@ fn mempool_setup_chainstate() {
 
                 // not enough funds
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 110000, &other_addr, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -592,11 +550,8 @@ fn mempool_setup_chainstate() {
                 });
 
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 99700, &other_addr, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -622,11 +577,8 @@ fn mempool_setup_chainstate() {
                     "bar",
                     &[Value::UInt(1)],
                 );
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -652,11 +604,8 @@ fn mempool_setup_chainstate() {
                     "foobar",
                     &[Value::UInt(1)],
                 );
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -682,11 +631,8 @@ fn mempool_setup_chainstate() {
                     "bar",
                     &[Value::UInt(1), Value::Int(2)],
                 );
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -705,11 +651,8 @@ fn mempool_setup_chainstate() {
 
                 let tx_bytes =
                     make_contract_publish(&contract_sk, 5, 1000, "foo_contract", FOO_CONTRACT);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -743,11 +686,8 @@ fn mempool_setup_chainstate() {
                 };
 
                 let tx_bytes = make_poison(&contract_sk, 5, 1000, microblock_1, microblock_2);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -777,11 +717,8 @@ fn mempool_setup_chainstate() {
                 };
 
                 let tx_bytes = make_poison(&contract_sk, 5, 1000, microblock_1, microblock_2);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -814,11 +751,8 @@ fn mempool_setup_chainstate() {
                 microblock_2.sign(&other_sk).unwrap();
 
                 let tx_bytes = make_poison(&contract_sk, 5, 1000, microblock_1, microblock_2);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -832,11 +766,8 @@ fn mempool_setup_chainstate() {
                 assert!(matches!(e, MemPoolRejection::Other(_)));
 
                 let tx_bytes = make_coinbase(&contract_sk, 5, 1000);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -893,11 +824,8 @@ fn mempool_setup_chainstate() {
                 microblock_2.sign(&secret_key).unwrap();
 
                 let tx_bytes = make_poison(&contract_sk, 5, 1000, microblock_1, microblock_2);
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -925,11 +853,8 @@ fn mempool_setup_chainstate() {
                     "baz",
                     &[Value::Principal(contract_principal)],
                 );
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,
@@ -955,11 +880,8 @@ fn mempool_setup_chainstate() {
                     "baz",
                     &[Value::Principal(contract_principal)],
                 );
-                let tx = StacksTransaction::consensus_deserialize_with_epoch(
-                    &mut tx_bytes.as_slice(),
-                    StacksEpochId::Epoch25,
-                )
-                .unwrap();
+                let tx =
+                    StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
                     .will_admit_mempool_tx(
                         &NULL_BURN_STATE_DB,

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -35,7 +35,7 @@ use stacks::chainstate::stacks::{
     TransactionPostConditionMode, TransactionSmartContract, TransactionSpendingCondition,
     TransactionVersion, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
-use stacks::codec::{DeserializeWithEpoch, StacksMessageCodec};
+use stacks::codec::StacksMessageCodec;
 use stacks::core::{StacksEpoch, StacksEpochExtension, StacksEpochId, CHAIN_ID_TESTNET};
 use stacks::util_lib::strings::StacksString;
 use stacks_common::address::AddressHashMode;
@@ -472,9 +472,7 @@ pub fn select_transactions_where(
         for tx in transactions.iter() {
             let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
-            let parsed =
-                StacksTransaction::consensus_deserialize_with_epoch(&mut &tx_bytes[..], epoch_id)
-                    .unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
             if test_fn(&parsed) {
                 result.push(parsed);
             }


### PR DESCRIPTION
### Description

Remove `DeserializeWithEpoch` trait. `cargo build` works, haven't tried `cargo test` yet. Also there are some unused `epoch_id` variables that Rust warns about that need to be removed