### PR TITLE
Multisig order independence

### DIFF
--- a/stackslib/src/chainstate/stacks/auth.rs
+++ b/stackslib/src/chainstate/stacks/auth.rs
@@ -710,11 +710,11 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::Singlesig(
             SinglesigSpendingCondition {
-                signer: signer_addr.bytes.clone(),
+                signer: signer_addr.bytes,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: SinglesigHashMode::P2PKH,
-                key_encoding: key_encoding,
+                key_encoding,
                 signature: MessageSignature::empty(),
             },
         ))
@@ -730,7 +730,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::Singlesig(
             SinglesigSpendingCondition {
-                signer: signer_addr.bytes.clone(),
+                signer: signer_addr.bytes,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: SinglesigHashMode::P2WPKH,
@@ -753,7 +753,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::Multisig(
             MultisigSpendingCondition {
-                signer: signer_addr.bytes.clone(),
+                signer: signer_addr.bytes,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: MultisigHashMode::P2SH,
@@ -776,7 +776,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::OrderIndependentMultisig(
             OrderIndependentMultisigSpendingCondition {
-                signer: signer_addr.bytes.clone(),
+                signer: signer_addr.bytes,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: OrderIndependentMultisigHashMode::P2SH,
@@ -799,7 +799,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::OrderIndependentMultisig(
             OrderIndependentMultisigSpendingCondition {
-                signer: signer_addr.bytes.clone(),
+                signer: signer_addr.bytes,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: OrderIndependentMultisigHashMode::P2WSH,
@@ -822,7 +822,7 @@ impl TransactionSpendingCondition {
 
         Some(TransactionSpendingCondition::Multisig(
             MultisigSpendingCondition {
-                signer: signer_addr.bytes.clone(),
+                signer: signer_addr.bytes,
                 nonce: 0,
                 tx_fee: 0,
                 hash_mode: MultisigHashMode::P2WSH,

--- a/stackslib/src/chainstate/stacks/block.rs
+++ b/stackslib/src/chainstate/stacks/block.rs
@@ -601,7 +601,7 @@ impl StacksBlock {
                 }
             }
             if !tx.auth.is_supported_in_epoch(epoch_id) {
-                error!("Order independent multisig transactions not supported before Stacks 3.0");
+                error!("Authentication mode not supported in Epoch {epoch_id}");
                 return false;
             }
         }

--- a/stackslib/src/chainstate/stacks/db/blocks.rs
+++ b/stackslib/src/chainstate/stacks/db/blocks.rs
@@ -6650,7 +6650,9 @@ impl StacksChainState {
         // 1: must parse (done)
 
         // 2: it must be validly signed.
-        StacksChainState::process_transaction_precheck(&chainstate_config, &tx)
+        let epoch = clarity_connection.get_epoch().clone();
+
+        StacksChainState::process_transaction_precheck(&chainstate_config, &tx, epoch)
             .map_err(|e| MemPoolRejection::FailedToValidate(e))?;
 
         // 3: it must pay a tx fee
@@ -6664,8 +6666,6 @@ impl StacksChainState {
         }
 
         // 4: check if transaction is valid in the current epoch
-        let epoch = clarity_connection.get_epoch().clone();
-
         if !StacksBlock::validate_transactions_static_epoch(&[tx.clone()], epoch) {
             return Err(MemPoolRejection::Other(
                 "Transaction is not supported in this epoch".to_string(),


### PR DESCRIPTION
### Description

Address PR comments from Jude:

- Remove unnecessary `.clone()`s
- Change error message
- Remove check from `process_transaction()`